### PR TITLE
chore(android): add missing CordovaResourceApi import

### DIFF
--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -36,6 +36,7 @@ import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CordovaPluginPathHandler;
+import org.apache.cordova.CordovaResourceApi;
 import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.LOG;
 import org.apache.cordova.PermissionHelper;


### PR DESCRIPTION
This PR fixes the build issue by adding the import for CordovaResourceApi.

```
/tmp/tmp-2762-B6MgpmWJvyrM/platforms/android/app/src/main/java/org/apache/cordova/file/FileUtils.java:1243: error: cannot find symbol
        final CordovaResourceApi resourceApi = webView.getResourceApi();
              ^
  symbol:   class CordovaResourceApi
  location: class FileUtils
/tmp/tmp-2762-B6MgpmWJvyrM/platforms/android/app/src/main/java/org/apache/cordova/file/FileUtils.java:1314: error: package CordovaResourceApi does not exist
                            CordovaResourceApi.OpenForReadResult resource = resourceApi.openForRead(fileUri);
                                              ^
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: /tmp/tmp-2762-B6MgpmWJvyrM/platforms/android/app/src/main/java/org/apache/cordova/file/AssetFilesystem.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
2 errors
```

This PR currently does not resolve the one test failure that seems to be common in both iOS and Android.

```
       resolveLocalFileSystemURL for cdvfile
        ✗ file.spec.147 should be able to resolve cdvfile applicationDirectory fs root
          - Expected [object Event] not to be defined.
```